### PR TITLE
update readme - command line usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ $ composer global require 'overtrue/package-builder' --prefer-source
  $ package-builder help
 ```
 
-## create a composer package:
+## Create a composer package:
+Make sure you have `~/.composer/vendor/bin/` in your path.
 
 ```
 package-builder build [target directory]


### PR DESCRIPTION
This is to avoid `command not found: package-builder` (https://github.com/overtrue/package-builder/issues/4)