### PR TITLE
Add phpunit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 .subsplit
 .php_cs.cache
 /*.phar
+/.idea

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
             "Overtrue\\PackageBuilder\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Overtrue\\Tests\\": "tests/"
+        }
+    },
     "require": {
         "symfony/console": "^3.0|^4.0",
         "symfony/process": "^3.0|^4.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,9 +9,6 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
         <testsuite name="Commands">
             <directory suffix="Test.php">./tests/Commands</directory>
         </testsuite>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,8 +9,11 @@
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
-        <testsuite name="Command">
-            <directory suffix="Test.php">./tests/Command</directory>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Commands">
+            <directory suffix="Test.php">./tests/Commands</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Command">
+            <directory suffix="Test.php">./tests/Command</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Commands/BuildCommandTest.php
+++ b/tests/Commands/BuildCommandTest.php
@@ -1,12 +1,21 @@
 <?php
 
+/*
+ * This file is part of the overtrue/package-builder.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Overtrue\Tests\Commands;
 
-use PHPUnit\Framework\TestCase;
 use Overtrue\PackageBuilder\Application;
-use Symfony\Component\Filesystem\Filesystem;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
 
 class BuildCommandTest extends TestCase
 {
@@ -68,17 +77,17 @@ class BuildCommandTest extends TestCase
             'n', // Do you want to use php-cs-fixer format your code ?
         ]);
         $this->commandTester->execute([
-            'command'   => $this->command->getName(),
-            'directory' => TEST_TEMP_DIR
+            'command' => $this->command->getName(),
+            'directory' => TEST_TEMP_DIR,
         ]);
 
-        $this->assertFileExists(TEST_TEMP_DIR . '/src/.gitkeep');
-        $this->assertFileExists(TEST_TEMP_DIR . '/composer.json');
-        $this->assertFileExists(TEST_TEMP_DIR . '/.editorconfig');
-        $this->assertFileExists(TEST_TEMP_DIR . '/.gitattributes');
-        $this->assertFileExists(TEST_TEMP_DIR . '/.gitignore');
+        $this->assertFileExists(TEST_TEMP_DIR.'/src/.gitkeep');
+        $this->assertFileExists(TEST_TEMP_DIR.'/composer.json');
+        $this->assertFileExists(TEST_TEMP_DIR.'/.editorconfig');
+        $this->assertFileExists(TEST_TEMP_DIR.'/.gitattributes');
+        $this->assertFileExists(TEST_TEMP_DIR.'/.gitignore');
 
-        $this->assertContains('test\/package-name', file_get_contents(TEST_TEMP_DIR . '/composer.json'));
+        $this->assertContains('test\/package-name', file_get_contents(TEST_TEMP_DIR.'/composer.json'));
     }
 
     public function testBuildPackageWithTestAndPhpCsConfig()
@@ -95,18 +104,18 @@ class BuildCommandTest extends TestCase
             'symfony', // Standard name of php-cs-fixer
         ]);
         $this->commandTester->execute([
-            'command'   => $this->command->getName(),
-            'directory' => TEST_TEMP_DIR
+            'command' => $this->command->getName(),
+            'directory' => TEST_TEMP_DIR,
         ]);
 
-        $this->assertFileExists(TEST_TEMP_DIR . '/src/.gitkeep');
-        $this->assertFileExists(TEST_TEMP_DIR . '/tests/.gitkeep');
-        $this->assertFileExists(TEST_TEMP_DIR . '/composer.json');
-        $this->assertFileExists(TEST_TEMP_DIR . '/.editorconfig');
-        $this->assertFileExists(TEST_TEMP_DIR . '/.gitattributes');
-        $this->assertFileExists(TEST_TEMP_DIR . '/.gitignore');
-        $this->assertFileExists(TEST_TEMP_DIR . '/phpunit.xml.dist');
-        $this->assertFileExists(TEST_TEMP_DIR . '/.php_cs');
+        $this->assertFileExists(TEST_TEMP_DIR.'/src/.gitkeep');
+        $this->assertFileExists(TEST_TEMP_DIR.'/tests/.gitkeep');
+        $this->assertFileExists(TEST_TEMP_DIR.'/composer.json');
+        $this->assertFileExists(TEST_TEMP_DIR.'/.editorconfig');
+        $this->assertFileExists(TEST_TEMP_DIR.'/.gitattributes');
+        $this->assertFileExists(TEST_TEMP_DIR.'/.gitignore');
+        $this->assertFileExists(TEST_TEMP_DIR.'/phpunit.xml.dist');
+        $this->assertFileExists(TEST_TEMP_DIR.'/.php_cs');
     }
 
     public function clearTestTempDir()

--- a/tests/Commands/BuildCommandTest.php
+++ b/tests/Commands/BuildCommandTest.php
@@ -2,6 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use Overtrue\PackageBuilder\Application;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -31,6 +32,13 @@ class BuildCommandTest extends TestCase
         $this->commandTester = new CommandTester($this->command);
     }
 
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->clearTestTempDir();
+    }
+
     public function testEmptyPackageName()
     {
         $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
@@ -41,7 +49,36 @@ class BuildCommandTest extends TestCase
     public function testInvalidPackageName()
     {
         $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
-        $this->commandTester->setInputs(['vendor']);
+        $this->commandTester->setInputs(['foo']);
         $this->commandTester->execute(['command' => $this->command->getName()]);
+    }
+
+    public function testNormal()
+    {
+        $this->commandTester->setInputs([
+            'overtrue/package-builder', // Name of package
+            'Overtrue\\PackageBuilder\\', // Namespace of package
+            'A composer package builder.', // description
+            'overtrue', // author name
+            'i@overtrue.me', // email
+            null, // License of package  MIT
+            'n', // Do you want to test this package ?
+            'n', // Do you want to use php-cs-fixer format your code ?
+        ]);
+        $this->commandTester->execute([
+            'command'   => $this->command->getName(),
+            'directory' => TEST_TEMP_DIR
+        ]);
+
+        $this->assertTrue(true);
+    }
+
+    public function clearTestTempDir()
+    {
+        $fileSystem = new Filesystem();
+
+        if ($fileSystem->exists(TEST_TEMP_DIR)) {
+            $fileSystem->remove(TEST_TEMP_DIR);
+        }
     }
 }

--- a/tests/Commands/BuildCommandTest.php
+++ b/tests/Commands/BuildCommandTest.php
@@ -53,7 +53,7 @@ class BuildCommandTest extends TestCase
         $this->commandTester->execute(['command' => $this->command->getName()]);
     }
 
-    public function testNormal()
+    public function testBuildPackageWithoutTestAndPhpCsConfig()
     {
         $this->commandTester->setInputs([
             'overtrue/package-builder', // Name of package
@@ -70,7 +70,11 @@ class BuildCommandTest extends TestCase
             'directory' => TEST_TEMP_DIR
         ]);
 
-        $this->assertTrue(true);
+        $this->assertFileExists(TEST_TEMP_DIR . '/src/.gitkeep');
+        $this->assertFileExists(TEST_TEMP_DIR . '/composer.json');
+        $this->assertFileExists(TEST_TEMP_DIR . '/.editorconfig');
+        $this->assertFileExists(TEST_TEMP_DIR . '/.gitattributes');
+        $this->assertFileExists(TEST_TEMP_DIR . '/.gitignore');
     }
 
     public function clearTestTempDir()

--- a/tests/Commands/BuildCommandTest.php
+++ b/tests/Commands/BuildCommandTest.php
@@ -1,8 +1,47 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use Overtrue\PackageBuilder\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
 
 class BuildCommandTest extends TestCase
 {
+    /**
+     * @var Application
+     */
+    protected $application;
 
+    /**
+     * @var Command
+     */
+    protected $command;
+
+    /**
+     * @var CommandTester
+     */
+    protected $commandTester;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->application = new Application('Package Builder', '@package_version@');
+        $this->command = $this->application->find('build');
+        $this->commandTester = new CommandTester($this->command);
+    }
+
+    public function testEmptyPackageName()
+    {
+        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        $this->commandTester->setInputs(['']);
+        $this->commandTester->execute(['command' => $this->command->getName()]);
+    }
+
+    public function testInvalidPackageName()
+    {
+        $this->expectException(\Symfony\Component\Console\Exception\RuntimeException::class);
+        $this->commandTester->setInputs(['vendor']);
+        $this->commandTester->execute(['command' => $this->command->getName()]);
+    }
 }

--- a/tests/Commands/BuildCommandTest.php
+++ b/tests/Commands/BuildCommandTest.php
@@ -58,11 +58,11 @@ class BuildCommandTest extends TestCase
     public function testBuildPackageWithoutTestAndPhpCsConfig()
     {
         $this->commandTester->setInputs([
-            'overtrue/package-builder', // Name of package
-            'Overtrue\\PackageBuilder\\', // Namespace of package
-            'A composer package builder.', // description
-            'overtrue', // author name
-            'i@overtrue.me', // email
+            'test/package-name', // Name of package
+            'Test\\PackageName', // Namespace of package
+            'Test description', // description
+            'test', // author name
+            'test@test.com', // email
             null, // License of package  MIT
             'n', // Do you want to test this package ?
             'n', // Do you want to use php-cs-fixer format your code ?
@@ -77,6 +77,8 @@ class BuildCommandTest extends TestCase
         $this->assertFileExists(TEST_TEMP_DIR . '/.editorconfig');
         $this->assertFileExists(TEST_TEMP_DIR . '/.gitattributes');
         $this->assertFileExists(TEST_TEMP_DIR . '/.gitignore');
+
+        $this->assertContains('test\/package-name', file_get_contents(TEST_TEMP_DIR . '/composer.json'));
     }
 
     public function clearTestTempDir()

--- a/tests/Commands/BuildCommandTest.php
+++ b/tests/Commands/BuildCommandTest.php
@@ -77,7 +77,7 @@ class BuildCommandTest extends TestCase
             'n', // Do you want to use php-cs-fixer format your code ?
         ]);
         $this->commandTester->execute([
-            'command' => $this->command->getName(),
+            'command'   => $this->command->getName(),
             'directory' => TEST_TEMP_DIR,
         ]);
 
@@ -104,7 +104,7 @@ class BuildCommandTest extends TestCase
             'symfony', // Standard name of php-cs-fixer
         ]);
         $this->commandTester->execute([
-            'command' => $this->command->getName(),
+            'command'   => $this->command->getName(),
             'directory' => TEST_TEMP_DIR,
         ]);
 

--- a/tests/Commands/BuildCommandTest.php
+++ b/tests/Commands/BuildCommandTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class BuildCommandTest extends TestCase
+{
+
+}

--- a/tests/Commands/BuildCommandTest.php
+++ b/tests/Commands/BuildCommandTest.php
@@ -81,6 +81,34 @@ class BuildCommandTest extends TestCase
         $this->assertContains('test\/package-name', file_get_contents(TEST_TEMP_DIR . '/composer.json'));
     }
 
+    public function testBuildPackageWithTestAndPhpCsConfig()
+    {
+        $this->commandTester->setInputs([
+            'test/package-name', // Name of package
+            'Test\\PackageName', // Namespace of package
+            'Test description', // description
+            'test', // author name
+            'test@test.com', // email
+            null, // License of package  MIT
+            'yes', // Do you want to test this package ?
+            'yes', // Do you want to use php-cs-fixer format your code ?
+            'symfony', // Standard name of php-cs-fixer
+        ]);
+        $this->commandTester->execute([
+            'command'   => $this->command->getName(),
+            'directory' => TEST_TEMP_DIR
+        ]);
+
+        $this->assertFileExists(TEST_TEMP_DIR . '/src/.gitkeep');
+        $this->assertFileExists(TEST_TEMP_DIR . '/tests/.gitkeep');
+        $this->assertFileExists(TEST_TEMP_DIR . '/composer.json');
+        $this->assertFileExists(TEST_TEMP_DIR . '/.editorconfig');
+        $this->assertFileExists(TEST_TEMP_DIR . '/.gitattributes');
+        $this->assertFileExists(TEST_TEMP_DIR . '/.gitignore');
+        $this->assertFileExists(TEST_TEMP_DIR . '/phpunit.xml.dist');
+        $this->assertFileExists(TEST_TEMP_DIR . '/.php_cs');
+    }
+
     public function clearTestTempDir()
     {
         $fileSystem = new Filesystem();

--- a/tests/Commands/BuildCommandTest.php
+++ b/tests/Commands/BuildCommandTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Overtrue\Tests\Commands;
+
 use PHPUnit\Framework\TestCase;
 use Overtrue\PackageBuilder\Application;
 use Symfony\Component\Filesystem\Filesystem;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,12 @@
 <?php
 
+/*
+ * This file is part of the overtrue/package-builder.
+ *
+ * (c) overtrue <i@overtrue.me>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 define('TEST_TEMP_DIR', 'tests/Temp');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,3 @@
 <?php
 
-// add some bootstrap steps here.
+define('TEST_TEMP_DIR', 'tests/Temp');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+// add some bootstrap steps here.


### PR DESCRIPTION
测试报告 `php vendor/bin/phpunit --coverage-text -c phpunit.xml`

```bash
PHPUnit 7.5.11 by Sebastian Bergmann and contributors.

....                                                                4 / 4 (100%)

Time: 1.2 seconds, Memory: 6.00 MB

OK (4 tests, 16 assertions)


Code Coverage Report:    
  2019-05-28 09:30:56    
                         
 Summary:                
  Classes: 50.00% (1/2)  
  Methods: 76.92% (10/13)
  Lines:   96.97% (96/99)

\Overtrue\PackageBuilder::Overtrue\PackageBuilder\Application
  Methods: 100.00% ( 1/ 1)   Lines: 100.00% (  3/  3)
\Overtrue\PackageBuilder\Commands::Overtrue\PackageBuilder\Commands\BuildCommand
  Methods:  75.00% ( 9/12)   Lines:  96.88% ( 93/ 96)
```


另外
-  `src/Commands/BuildCommand.php` 中的  `camelCase` 方法未用到，是否可以删除?
- 运行测试时，会在 `tests` 目录下新增测试文件夹 `Temp`，测试结束后会自动删除。

贴上 phpstorm 的一个测试覆盖截图

![image](https://user-images.githubusercontent.com/9459488/58467697-b4ba3a80-816e-11e9-842b-29910ec27549.png)
