### PR TITLE
 兼容vendor名称带横杠、下划线的情况

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -109,7 +109,7 @@ class BuildCommand extends Command
         // vendor/namespace
         $question = new Question("Namespace of package [<fg=yellow>{$defaultNamespace}</fg=yellow>]: ", $defaultNamespace);
         $this->info['NAMESPACE'] = $helper->ask($input, $output, $question);
-        $this->info['VENDOR'] = strtolower(explode('/', $this->info['PACKAGE_NAME'])[0]);
+        $this->info['VENDOR'] = strtolower(strstr($this->info['PACKAGE_NAME'], '/', true));
         $this->info['PACKAGE'] = substr($this->info['PACKAGE_NAME'], strlen($this->info['VENDOR']) + 1);
 
         // description

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -109,7 +109,7 @@ class BuildCommand extends Command
         // vendor/namespace
         $question = new Question("Namespace of package [<fg=yellow>{$defaultNamespace}</fg=yellow>]: ", $defaultNamespace);
         $this->info['NAMESPACE'] = $helper->ask($input, $output, $question);
-        $this->info['VENDOR'] = strtolower(strstr($this->info['NAMESPACE'], '\\', true));
+        $this->info['VENDOR'] = strtolower(explode('/', $this->info['PACKAGE_NAME'])[0]);
         $this->info['PACKAGE'] = substr($this->info['PACKAGE_NAME'], strlen($this->info['VENDOR']) + 1);
 
         // description


### PR DESCRIPTION
在获取 `NAMESPACE` 时，`studlyCase` 会删除`PACKAGE_NAME` 中的 `-`、`_`。

例如 `PACKAGE_NAME` 为 `her-cat/test`

`VENDOR` 是 `hercat`，`PACKAGE` 多了一个斜杠 `/test`
