### PR TITLE
适配新版php-cs-fixer 3.0.0

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -259,7 +259,7 @@ class BuildCommand extends Command
      */
     protected function createCSFixerConfiguration()
     {
-        $this->copyFile('php_cs', '.php_cs');
+        $this->copyFile('php_cs', '.php-cs-fixer.php');
     }
 
     /**

--- a/src/stubs/gitignore
+++ b/src/stubs/gitignore
@@ -5,4 +5,4 @@
 sftp-config.json
 composer.lock
 .subsplit
-.php_cs.cache
+.php-cs-fixer.cache

--- a/src/stubs/php_cs
+++ b/src/stubs/php_cs
@@ -1,6 +1,7 @@
 <?php
-return PhpCsFixer\Config::create()
-    ->setRules([
+$config = new PhpCsFixer\Config();
+
+return $config->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
         'blank_line_after_opening_tag' => true,


### PR DESCRIPTION
- .php_cs rename to .php-cs-fixer.php
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/ec587dba94c3b99ecbdea17554dc1c749b751569/src/Console/ConfigurationResolver.php#L254-L261

- php_cs.cache rename to .php-cs-fixer.cache
- PhpCsFixer\Config 移除了create方法。
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/ec587dba94c3b99ecbdea17554dc1c749b751569/src/Config.php